### PR TITLE
Two updates

### DIFF
--- a/common/enforcer_rules_physics.json
+++ b/common/enforcer_rules_physics.json
@@ -6,6 +6,12 @@
       "num_copies": 1,
       "destinations": ["site.name in [T1_US_FNAL_Disk T2_US_*]"],
       "sources": ["site.storage_type == DISK and site.name notin [T1_US_FNAL_Disk T2_US_*]"]
+    },
+    "ral_offload": {
+      "replicas": ["replica.num_full_other_copy_common_owner == 0"],
+      "num_copies": 1,
+      "destinations": ["site.name == T1_UK_RAL_ECHO_Disk"],
+      "sources": ["site.name == T1_UK_RAL_Disk"]
     }
   }
 }

--- a/detox/Express.txt
+++ b/detox/Express.txt
@@ -9,7 +9,8 @@ Until never
 
 ProtectBlock blockreplica.is_locked
 
-ProtectBlock blockreplica.last_update newer_than 60 days ago
+# 2592000 = 60 x 60 x 24 x 30
+ProtectBlock blockreplica.age_relative_to_newest < 2592000
 
 Protect dataset.name == /*/*/ALCARECO and replica.first_block_created newer_than January 1
 Protect dataset.name == /*/*/ALCAPROMPT and replica.first_block_created newer_than January 1


### PR DESCRIPTION
1. Enforcer: add a rule to offload RAL_Disk to RAL_ECHO_Disk
2. Detox Express partition: use new variable blockreplica.age_relative_to_newest to clean old blocks counting from the last updated block